### PR TITLE
fix icon loading fallback and remove axios

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 🎉更新内容及更新方法见[保姆级教程](https://moyuguy.github.io/docs_notion_bookmarks/guide/getting-started.html)
 
 <details>
+  <summary> 2026/6/23</summary>
+ - 2026/6/23 修复网站图标加载异常：远程图标请求超时或失败时会停止加载动画，并显示本地默认图标兜底；如果远程图标随后加载成功，会自动恢复真实图标。</br>
+ - 移除未使用的 axios 依赖，处理 GitHub Dependabot 的 axios 安全告警。</br>
+ - 项目继续使用 pnpm 管理依赖，请保留 `pnpm-lock.yaml`，不要提交 `package-lock.json`。</br>
+</details>
+
+<details>
   <summary> 2025/5/19</summary>
  - 2025/5/19 新增小组件功能，简易时钟/天气/圆形时钟/IP信息/热搜</br>
   <img width="800" alt="demo" src="https://github.com/user-attachments/assets/d81be672-06b9-4df9-b1ec-a80d406284c0" />
@@ -37,4 +44,18 @@
 ## 快速开始
 [保姆级教程](https://ezho.top/code/2025/02/21/notion-bookmarks-handbook)
 
+### 本地开发
+
+```bash
+pnpm install
+pnpm dev
+```
+
+常用检查命令：
+
+```bash
+pnpm test
+pnpm lint
+pnpm build
+```
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test -r ts-node/register src/lib/*.test.cts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
@@ -17,7 +18,6 @@
     "@vercel/analytics": "^1.6.1",
     "@vercel/kv": "^3.0.0",
     "@vercel/speed-insights": "^1.3.1",
-    "axios": "^1.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "critters": "^0.0.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(next@15.1.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      axios:
-        specifier: ^1.10.0
-        version: 1.10.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -899,9 +896,6 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axios@1.10.0:
-    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
-
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1315,15 +1309,6 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
-
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -1928,9 +1913,6 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3049,14 +3031,6 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios@1.10.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.3
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
@@ -3626,8 +3600,6 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.3.3: {}
-
-  follow-redirects@1.15.9: {}
 
   for-each@0.3.5:
     dependencies:
@@ -4229,8 +4201,6 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/components/ui/LinkCard.tsx
+++ b/src/components/ui/LinkCard.tsx
@@ -3,9 +3,17 @@
 import { Link } from '@/types';
 import { motion } from 'framer-motion';
 import { IconExternalLink } from '@tabler/icons-react';
-import React, { useState, useEffect, memo, useCallback } from 'react';
+import React, { useState, useEffect, memo, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '@/lib/utils';
+import {
+  FALLBACK_ICON_SRC,
+  ICON_LOAD_TIMEOUT_MS,
+  getFailedIconState,
+  getInitialIconState,
+  getLoadedIconState,
+  getTimedOutIconState,
+} from '@/lib/link-icon';
 
 interface LinkCardProps {
   link: Link;
@@ -36,22 +44,6 @@ function Tooltip({ content, show, x, y }: { content: string; show: boolean; x: n
   );
 }
 
-// 获取图标URL的辅助函数
-function getIconUrl(link: Link): string {
-  // 最优先使用iconfile
-  if (link.iconfile) {
-    return link.iconfile;
-  }
-  
-  // 次优先级使用iconlink
-  if (link.iconlink) {
-    return link.iconlink;
-  }
-  
-  // 如果都没有，直接使用默认图标
-  return '/globe.svg';
-}
-
 // 分离 Image 组件以避免整个 LinkCard 重渲染
 const OptimisedLinkIcon = memo(function OptimisedLinkIcon({ 
   src, 
@@ -64,8 +56,42 @@ const OptimisedLinkIcon = memo(function OptimisedLinkIcon({
   onLoad?: () => void; 
   onError: () => void;
 }) {
+    const imageRef = useRef<HTMLImageElement>(null);
+
+    useEffect(() => {
+        const image = imageRef.current;
+        if (!image) return;
+
+        const reportImageStatus = () => {
+            if (!image.complete) return false;
+
+            if (image.naturalWidth > 0) {
+                onLoad?.();
+            } else {
+                onError();
+            }
+
+            return true;
+        };
+
+        if (reportImageStatus()) return;
+
+        let attempts = 0;
+        const intervalId = window.setInterval(() => {
+            attempts += 1;
+            if (reportImageStatus() || attempts >= 30) {
+                window.clearInterval(intervalId);
+            }
+        }, 1000);
+
+        return () => window.clearInterval(intervalId);
+    }, [src, onLoad, onError]);
+
     return (
+        // 这里刻意使用原生 img，避免 Vercel Image Optimization 免费额度消耗。
+        // eslint-disable-next-line @next/next/no-img-element
         <img
+            ref={imageRef}
             src={src}
             alt={alt}
             className={cn(
@@ -78,23 +104,22 @@ const OptimisedLinkIcon = memo(function OptimisedLinkIcon({
             fetchPriority="low"
         />
     );
-}, (prev, next) => prev.src === next.src);
+}, (prev, next) => prev.src === next.src && prev.alt === next.alt);
 
 
 const LinkCard = memo(function LinkCard({ link, className }: LinkCardProps) {
   const [titleTooltip, setTitleTooltip] = useState({ show: false, x: 0, y: 0 });
   const [descTooltip, setDescTooltip] = useState({ show: false, x: 0, y: 0 });
-  const [imageLoaded, setImageLoaded] = useState(false);
-  const [imageSrc, setImageSrc] = useState(getIconUrl(link));
+  const [iconState, setIconState] = useState(() => getInitialIconState(link));
+  const iconContainerRef = useRef<HTMLDivElement>(null);
 
     // 使用 useCallback 优化事件处理
     const handleImageError = useCallback(() => {
-        setImageSrc('/globe.svg');
-        setImageLoaded(true);
+        setIconState(getFailedIconState());
     }, []);
 
     const handleImageLoad = useCallback(() => {
-        setImageLoaded(true);
+        setIconState((state) => getLoadedIconState(state));
     }, []);
 
   const handleMouseEnter = useCallback((
@@ -117,9 +142,55 @@ const LinkCard = memo(function LinkCard({ link, className }: LinkCardProps) {
 
   // 当 link 变化时更新图片源
   useEffect(() => {
-    setImageSrc(getIconUrl(link));
-    setImageLoaded(false);
+    setIconState(getInitialIconState(link));
   }, [link]);
+
+  useEffect(() => {
+    if (iconState.isLoaded || iconState.src === FALLBACK_ICON_SRC) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setIconState((state) => {
+        if (state.isLoaded || state.src === FALLBACK_ICON_SRC) {
+          return state;
+        }
+
+        return getTimedOutIconState(state);
+      });
+    }, ICON_LOAD_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [iconState.isLoaded, iconState.src]);
+
+  useEffect(() => {
+    if (!iconState.showFallback) return;
+
+    const syncImageStatus = () => {
+      const image = iconContainerRef.current?.querySelector('img');
+      if (!image?.complete) return false;
+
+      if (image.naturalWidth > 0) {
+        setIconState((state) => getLoadedIconState(state));
+      } else {
+        setIconState(getFailedIconState());
+      }
+
+      return true;
+    };
+
+    if (syncImageStatus()) return;
+
+    let attempts = 0;
+    const intervalId = window.setInterval(() => {
+      attempts += 1;
+      if (syncImageStatus() || attempts >= 30) {
+        window.clearInterval(intervalId);
+      }
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [iconState.showFallback]);
 
   return (
     <>
@@ -148,15 +219,22 @@ const LinkCard = memo(function LinkCard({ link, className }: LinkCardProps) {
               className="relative w-10 h-10 rounded-xl overflow-hidden transition-all shrink-0
                        bg-muted/50 p-1.5 border border-border/50"
             >
-              <div className="icon-container relative w-full h-full">
+              <div ref={iconContainerRef} className="icon-container relative w-full h-full">
+                {iconState.showFallback && (
+                  <div
+                    aria-hidden="true"
+                    className="absolute inset-0 bg-center bg-contain bg-no-repeat opacity-70"
+                    style={{ backgroundImage: `url(${FALLBACK_ICON_SRC})` }}
+                  />
+                )}
                 <OptimisedLinkIcon 
-                    src={imageSrc} 
+                    src={iconState.src} 
                     alt={link.name} 
                     onLoad={handleImageLoad}
                     onError={handleImageError}
                 />
                  
-                {!imageLoaded && (
+                {iconState.showSpinner && (
                   <div className="absolute inset-0 flex items-center justify-center bg-muted/20">
                     <div className="w-6 h-6 border-2 border-primary/20 border-t-primary rounded-full animate-spin"></div>
                   </div>

--- a/src/lib/link-icon.test.cts
+++ b/src/lib/link-icon.test.cts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  FALLBACK_ICON_SRC,
+  getFailedIconState,
+  getInitialIconState,
+  getLinkIconUrl,
+  getTimedOutIconState,
+} = require('./link-icon');
+
+test('优先使用 Notion 上传的 iconfile', () => {
+  const iconUrl = getLinkIconUrl({
+    iconfile: 'https://static.example.com/icon.png',
+    iconlink: 'https://example.com/favicon.ico',
+  });
+
+  assert.equal(iconUrl, 'https://static.example.com/icon.png');
+});
+
+test('没有 iconfile 时使用 iconlink', () => {
+  const iconUrl = getLinkIconUrl({
+    iconfile: '',
+    iconlink: 'https://example.com/favicon.ico',
+  });
+
+  assert.equal(iconUrl, 'https://example.com/favicon.ico');
+});
+
+test('没有远程图标时直接使用本地图标且不显示 loading', () => {
+  const state = getInitialIconState({
+    iconfile: '',
+    iconlink: '',
+  });
+
+  assert.deepEqual(state, {
+    src: FALLBACK_ICON_SRC,
+    isLoaded: true,
+    hasFailed: false,
+    showFallback: false,
+    showSpinner: false,
+  });
+});
+
+test('远程图标失败或超时后切到本地图标并结束 loading', () => {
+  const state = getFailedIconState();
+
+  assert.deepEqual(state, {
+    src: FALLBACK_ICON_SRC,
+    isLoaded: true,
+    hasFailed: true,
+    showFallback: false,
+    showSpinner: false,
+  });
+});
+
+test('远程图标超时后保留原始 src，允许后续加载完成时显示真实图标', () => {
+  const state = getTimedOutIconState({
+    src: 'https://slow.example.com/favicon.ico',
+    isLoaded: false,
+    hasFailed: false,
+    showFallback: false,
+    showSpinner: true,
+  });
+
+  assert.deepEqual(state, {
+    src: 'https://slow.example.com/favicon.ico',
+    isLoaded: false,
+    hasFailed: false,
+    showFallback: true,
+    showSpinner: false,
+  });
+});

--- a/src/lib/link-icon.ts
+++ b/src/lib/link-icon.ts
@@ -1,0 +1,73 @@
+export const FALLBACK_ICON_SRC = '/globe.svg';
+export const ICON_LOAD_TIMEOUT_MS = 4000;
+
+type LinkIconSource = {
+  iconfile?: string | null;
+  iconlink?: string | null;
+};
+
+export type IconLoadState = {
+  src: string;
+  isLoaded: boolean;
+  hasFailed: boolean;
+  showFallback: boolean;
+  showSpinner: boolean;
+};
+
+export function getLinkIconUrl(link: LinkIconSource): string {
+  if (link.iconfile) {
+    return link.iconfile;
+  }
+
+  if (link.iconlink) {
+    return link.iconlink;
+  }
+
+  return FALLBACK_ICON_SRC;
+}
+
+export function getInitialIconState(link: LinkIconSource): IconLoadState {
+  const src = getLinkIconUrl(link);
+
+  return {
+    src,
+    isLoaded: src === FALLBACK_ICON_SRC,
+    hasFailed: false,
+    showFallback: false,
+    showSpinner: src !== FALLBACK_ICON_SRC,
+  };
+}
+
+export function getLoadedIconState(state: IconLoadState): IconLoadState {
+  return {
+    ...state,
+    isLoaded: true,
+    showFallback: false,
+    showSpinner: false,
+  };
+}
+
+export function getFailedIconState(): IconLoadState {
+  return {
+    src: FALLBACK_ICON_SRC,
+    isLoaded: true,
+    hasFailed: true,
+    showFallback: false,
+    showSpinner: false,
+  };
+}
+
+export function getTimedOutIconState(state: IconLoadState): IconLoadState {
+  if (state.isLoaded || state.src === FALLBACK_ICON_SRC) {
+    return {
+      ...state,
+      showSpinner: false,
+    };
+  }
+
+  return {
+    ...state,
+    showFallback: true,
+    showSpinner: false,
+  };
+}


### PR DESCRIPTION
## Summary

- Stop bookmark icons from spinning indefinitely by adding timeout, fallback, and late-load recovery logic.
- Remove the unused axios dependency and update the pnpm lockfile to clear axios Dependabot alerts.
- Document the pnpm workflow and the icon/security maintenance note in README.

## Validation

- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org npx --yes pnpm@10.34.4 run test`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org npx --yes pnpm@10.34.4 run lint`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org npx --yes pnpm@10.34.4 run build`
- Production audit check confirmed `axiosAdvisories: 0`.

## Notes

`next/image` is intentionally not used for bookmark favicons so the site does not consume Vercel Image Optimization quota on the free plan.